### PR TITLE
Deal with the absence of a .rush.toml file and refactor read_config_prompt

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 extern crate toml;
 
+use config::toml::Table;
 use std::io::{Read, BufReader};
 use std::fs::File;
 use std::env::{set_var, var, home_dir};
@@ -9,7 +10,7 @@ use prompt::Prompt;
 ///Read in Config
 ///Inner function used to pull in a default configuration file for parsing
 ///or the customized one if it exists
-fn read_in_config() -> String {
+fn read_in_config() -> Option<String> {
     //Find a way to read from default if this doesn't work. let a = if else?
     let mut home_config = home_dir().expect("No Home directory");
     home_config.push(".rush.toml");
@@ -18,7 +19,7 @@ fn read_in_config() -> String {
                                      turn into a str"));
     let config = if default.is_err() {
         //Should be changed to location of git repo if compiling on your own machine
-        File::open("./config/rush.toml").expect("No default file")
+        return None;
     } else {
         default.expect("No files to open for config")
     };
@@ -26,79 +27,53 @@ fn read_in_config() -> String {
     let mut buffer_string = String::new();
     reader.read_to_string(&mut buffer_string)
         .expect("Failed to read in config");
-    buffer_string
+    Some(buffer_string)
 }
 
 ///Read Config Prompt
 ///Used to read the options of the config file and parse
 ///the defined options to create a customized prompt
-#[cfg(unix)]
 pub fn read_config_prompt(input: &Prompt) -> String {
     let buffer_string = read_in_config();
 
-    let value: toml::Value = buffer_string.parse()
-        .expect("Should have a config file");
-    let left = value.lookup("prompt.left")
-        .expect("Expected value left in rush.toml").as_str()
-        .expect("Failed to convert to str").split('%');
-    let mut prompt = "".to_owned();
+    let config: Option<toml::Value> = buffer_string
+        .map(|b| b.parse().expect("Should have a config file"));
+    let left_value = config.as_ref().and_then(|config| config.lookup("prompt.left"));
+    let default_prompt = format!("rush-{}$", env!("CARGO_PKG_VERSION"));
+    let mut left = left_value
+        .map_or(&default_prompt as &str, |left_value| left_value.as_str().unwrap()).split('%');
+    let mut prompt = left.next().unwrap().to_string();
     for i in left {
         if !i.is_empty() {
-            match i.chars().nth(0).expect("Failed to parse string") {
-                'U' => prompt.push_str(&var("USER")
-                    .expect("No user env variable")),
-                'H' => prompt.push_str(String::from_utf8(Command::new("uname")
-                    .arg("-n").output()
-                    .expect("No uname command").stdout)
-                    .expect("Failed to convert to string")
-                    .trim()),
-                'L' => prompt.push_str(&input.get_cwd()),
-                'R' => prompt.push('$'),
-                _ => prompt.push(i.chars().nth(0).expect("Failed to parse string")),
+            let escape: Result<String, ()> = interpret_escapes(i.chars().next().unwrap(), input);
+            match escape {
+                Ok(e) => prompt.push_str(&e),
+                Err(_) => prompt.push_str("Failed to parse escape"),
             }
-        }
-        //Add non Prompt special chars to prompt
-        if i.len() > 1 {
-            for j in 1..i.len() {
-                prompt.push(i.chars().nth(j).expect("Failed to parse string"));
-            }
+            //Add non Prompt special chars to prompt
+            prompt.push_str(&i[1..]);
         }
     }
     prompt.push(' ');
     prompt
 }
 
-#[cfg(windows)]
-pub fn read_config_prompt(input: &Prompt) -> String {
-    let buffer_string = read_in_config();
+fn interpret_escapes(escape: char, input: &Prompt) -> Result<String, ()> {
+    match escape {
+        'U' if cfg!(windows) => Ok(var("USERNAME").expect("$USERNAME not set")),
+        'U' if cfg!(unix)    => Ok(var("USER").expect("$USER not set")),
+        'H' if cfg!(windows) => Ok(var("USERDOMAIN").expect("$USERDOMAIN not set")),
+        'H' if cfg!(unix)    =>
+            Ok(String::from_utf8(Command::new("uname")
+            .arg("-n").output()
+            .expect("No uname command").stdout)
+            .expect("Failed to convert to string")
+            .trim().to_string()),
 
-    let value: toml::Value = buffer_string.parse()
-        .expect("Should have a config file");
-    let left = value.lookup("prompt.left")
-        .expect("Expected value left in rush.toml").as_str()
-        .expect("Failed to convert to str").split('%');
-    let mut prompt = "".to_owned();
-    for i in left {
-        if !i.is_empty() {
-            match i.chars().nth(0).expect("Failed to parse string") {
-                'U' => prompt.push_str(&var("USERNAME")
-                    .expect("No user env variable")),
-                'H' => prompt.push_str(&var("USERDOMAIN")
-                    .expect("No user env variable")),
-                'L' => prompt.push_str(&input.get_cwd()),
-                'R' => prompt.push('$'),
-                _ => prompt.push(i.chars().nth(0).expect("Failed to parse string")),
-            }
-        }
-        //Add non Prompt special chars to prompt
-        if i.len() > 1 {
-            for j in 1..i.len() {
-                prompt.push(i.chars().nth(j).expect("Failed to parse string"));
-            }
-        }
+        'L' => Ok(input.get_cwd()),
+        'R' => Ok("$".to_string()),
+        _ => Err(()),
     }
-    prompt.push(' ');
-    prompt
 }
 
 ///Check Alias
@@ -119,38 +94,36 @@ pub fn check_alias(input: String) -> Option<String> {
 
     //Check the config file for the key
     let config = read_in_config();
-    let mut parsed = toml::Parser::new(&config)
-        .parse().expect("Failed to pars config");
-    let alias_table = parsed.remove("alias")
-        .expect("Add an [alias] field to your config");
-    let alias = alias_table.lookup(alias_key);
+    let parsed: Option<Table> = config.map(|config| toml::Parser::new(&config)
+        .parse().expect("Failed to parse config"));
+    let alias_table = parsed.as_ref().and_then(|parsed| parsed.get("alias"));
+    let alias = alias_table.and_then(|alias_table|alias_table.lookup(alias_key));
 
     //Checks if alias is in config file
-    if !alias.is_some() {
-        return None;
+    if let Some(alias) = alias {
+        toml::decode(alias
+            .to_owned()).expect("Failed to decode value")
+    } else {
+        None
     }
-    let output: String = toml::decode(alias
-        .expect("Already checked if alias is a none value")
-        .to_owned()).expect("Failed to decode value");
-    Some(output)
 }
 
 ///Set Env Var
 ///Sets system environment variables based on the configuration file
 pub fn set_env_var() {
     let config = read_in_config();
-    let mut parsed = toml::Parser::new(&config).parse().expect("Config parse unsuccessful");
-    let env_table = parsed.remove("env_var")
-        .expect("Add an [env_var] field to your config");
+    let parsed: Option<Table> = config.map(|config| toml::Parser::new(&config)
+        .parse().expect("Failed to parse config"));
 
-    //Grab all the keys, loop through, decode the value, and set the env variables
-    let keys: Vec<_> = env_table.as_table().expect("Failed to convert to table").keys().cloned().collect();
-    for key in keys {
-        let value_unparsed: String = toml::decode(env_table.lookup(&key)
-            .expect("Failed lookup")
-            .to_owned())
-            .expect("Failed to decode value");
-        set_var(key, env_parse(value_unparsed));
+    if let Some(env_table) = parsed.as_ref().and_then(|parsed| parsed.get("env_var")) {
+        //Grab all the keys, loop through, decode the value, and set the env variables
+        let iter = env_table.as_table().expect("Failed to convert to table").iter();
+        for (key, value) in iter {
+            let value_unparsed: String = toml::decode(value
+                .to_owned())
+                .expect("Failed to decode value");
+            set_var(key, env_parse(value_unparsed));
+        }
     }
 }
 


### PR DESCRIPTION
`read_in_config` now returns an `Option<String>` and code that uses it now manipulates `Option`s.
The platform-specific `read_config_prompt`s are combined and the platform-specific behavior is now delegated to `interpret_escapes`, which uses the `cfg` macro for platform detection instead of multiple function definitions.
