### PR TITLE
Update to rustyline 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ path = "src/lib.rs"
 [dependencies]
 toml = "0.2.1"
 libc = "0.2.32"
-rustyline = { git="https://github.com/kkawakam/rustyline.git" }
 nix = "0.9.0"
+rustyline = "2.0.0"
 
 #libc = { git = "https://github.com/rust-lang/libc.git" }
 #nix = { git = "https://github.com/nix-rust/nix.git" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,10 @@ use rush::builtins;
 use rush::prompt::Prompt;
 use rush::interpeter::*;
 use rustyline::error::ReadlineError;
-use rustyline::{Config, CompletionType, Editor};
-use rustyline::completion::FilenameCompleter;
+use rustyline::{Config, CompletionType, Editor, Helper};
+use rustyline::completion::{Completer, FilenameCompleter, Pair};
+use rustyline::hint::Hinter;
+use rustyline::highlight::Highlighter;
 use std::env::home_dir;
 use std::process;
 use std::env;
@@ -18,7 +20,40 @@ use std::io::{BufReader, BufRead};
 use std::fs::File;
 use nix::sys::signal;
 use nix::sys::signal::{SigAction, SigHandler, SaFlags, SigSet, sigaction};
+use std::borrow::Cow::{self, Borrowed, Owned};
 
+
+struct RushHelper(FilenameCompleter);
+
+impl Completer for RushHelper {
+    type Candidate = Pair;
+
+    fn complete(&self, line: &str, pos: usize) -> Result<(usize, Vec<Pair>), ReadlineError> {
+        self.0.complete(line, pos)
+    }
+}
+
+impl Highlighter for RushHelper {
+    fn highlight_prompt<'p>(&self, prompt: &'p str) -> Cow<'p, str> {
+        Borrowed(prompt)
+    }
+
+    fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
+        Owned("\x1b[1m".to_owned() + hint + "\x1b[m")
+    }
+}
+
+impl Hinter for RushHelper {
+    fn hint(&self, line: &str, _pos: usize) -> Option<String> {
+        if line == "hello" {
+            Some(" World".to_owned())
+        } else {
+            None
+        }
+    }
+}
+
+impl Helper for RushHelper {}
 
 fn main() {
     #[cfg(unix)]    {
@@ -88,7 +123,7 @@ fn main() {
     // Set up buffer to read inputs and History Buffer
     let input_config = Config::builder().completion_type(CompletionType::List).build();
     let mut input_buffer = Editor::with_config(input_config);
-    input_buffer.set_completer(Some(FilenameCompleter::new()));
+    input_buffer.set_helper(Some(RushHelper(FilenameCompleter::new())));
     if let Err(_) = input_buffer.load_history(history) {
         println!("No previous history.");
     }


### PR DESCRIPTION
Rustyline 2.0.0 is stable.
This PR updates to the latest upstream version.
`set_completer` is deprecated and was therefore replaced with `set_helper` as suggested by the [`rustyline` example code](https://github.com/kkawakam/rustyline/blob/master/examples/example.rs).